### PR TITLE
Add support for passing jwt in the query string

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@
 	<script type="text/javascript">
 		window.onload = function() {
 			document.getElementById('encoded').focus();
+			var querystringParameter = getParameterByName("jwt");
+			if (querystringParameter)
+			{
+				document.getElementById('encoded').value = querystringParameter;
+				document.getElementById('encoded').onchange();
+			}
 		}
 
 		function decode() {
@@ -30,11 +36,17 @@
 					var payloadString = decodeURIComponent(escape(atob(base64Payload)));
 					var payload = JSON.parse(payloadString);
 					document.getElementById('decoded').textContent = JSON.stringify(payload, null, 2);
+					document.getElementById('encoded').blur();
 				}
 				catch (e) {
 					document.getElementById('decoded').textContent = "invalid jwt";
 				}
 			}, 0);
+		}
+
+		function getParameterByName(name) {
+			var match = RegExp('[?&]' + name + '=([^&]*)').exec(window.location.search);
+			return match && decodeURIComponent(match[1].replace(/\+/g, ' '));
 		}
 	</script>
 </html>


### PR DESCRIPTION
With this patch we take a look in the url, if there's a query string
parameter called `jwt`, we decode its value immediately, eliminating the
need for pasting the token.