### PR TITLE
Bugfix: URL encode input values, don't treat empty strings as JWTs

### DIFF
--- a/components/Claim.vue
+++ b/components/Claim.vue
@@ -30,7 +30,7 @@ export default {
       return new Date(this.value * 1000).toString().replace(/ *\([^)]*\) */g, "");
     },
     jwtLink() {
-      return "/decode/" + this.value;
+      return { name: "decode-jwt", params: { jwt: this.value } };
     }
   }
 }

--- a/components/Demo.vue
+++ b/components/Demo.vue
@@ -5,7 +5,7 @@ const router = useRouter();
 
 async function setDemoToken() {
   const demoToken = await JwtIssuer.issueDemoToken();
-  router.push({path: `/decode/${demoToken}`})
+  router.push({ name: "decode-jwt", params: { jwt: demoToken } });
 }
 </script>
 

--- a/components/EncodedJwtInput.vue
+++ b/components/EncodedJwtInput.vue
@@ -21,7 +21,7 @@ function blurInput(event) {
 
 /* When there's a change, navigate to a url that will show the jwt. */
 function change(event) {
-  router.push({ path: `/decode/${event.target.value}` })
+  router.push({ name: `decode-jwt`, params: { jwt: event.target.value } });
 }
 
 onMounted(() => {

--- a/pages/[jwt].vue
+++ b/pages/[jwt].vue
@@ -5,7 +5,7 @@ const router = useRouter();
 const jwt = route.params.jwt;
 
 if (jwt)
-  router.push(`/decode/${jwt}`);
+  router.push({ name: "decode-jwt", params: { jwt } });
 </script>
 
 <template>

--- a/utils/isJwt.js
+++ b/utils/isJwt.js
@@ -1,3 +1,3 @@
 export const isJwt = (checkThis) => {
-  return JwtDecoder.decode(checkThis) !== "invalid jwt";
+  return !!checkThis && JwtDecoder.decode(checkThis) !== "invalid jwt";
 }


### PR DESCRIPTION
THANK YOU FOR THIS WONDERFUL TOOL 💯 

Entering a value with special characters (such as a URL) currently 404s because the input value is not URL encoded before being appended to the route.

This PR makes programmatic navigation use route name + params rather than manually constructing the path, which automatically encodes the `jwt` route param.

When using this syntax, Nuxt complains if required route parameters are missing. This revealed a bug where empty string claims were treated as JWTs and generate an (invisible) link element. Now, a value must be truthy to be treated as a JWT.